### PR TITLE
Added no harp line warning as red title on the plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     'scipy',
     'rich',
     'spikeinterface[full]==0.100.7',
-    'harp-python @ git+https://github.com/jsiegle/harp-python@decode-clock'
+    'harp-python @ git+https://github.com/jsiegle/harp-python@decode-clock',
+    'numpy==1.26.4'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_ephys_rig_qc/generate_report.py
+++ b/src/aind_ephys_rig_qc/generate_report.py
@@ -94,7 +94,8 @@ def generate_qc_report(
             # optionally align to Harp timestamps
             print("Aligning timestamps to Harp clock...")
             align_timestamps_harp(
-                directory, pdf=pdf,
+                directory,
+                pdf=pdf,
             )
 
     print("Creating QC plots...")
@@ -275,7 +276,8 @@ def create_qc_plots(
                 pdf.write(h=10, text=f"Duration: {duration} s")
                 pdf.set_y(65)
                 pdf.write(
-                    h=10, text=f"Sample Rate: " f"{sample_rate} Hz",
+                    h=10,
+                    text=f"Sample Rate: " f"{sample_rate} Hz",
                 )
                 pdf.set_y(70)
                 pdf.write(h=10, text=f"Channels: {stream.samples.shape[1]}")
@@ -321,14 +323,18 @@ def create_qc_plots(
 
 
 if __name__ == "__main__":
+    output_stream = io.StringIO()
+    sys.stdout = output_stream
     if len(sys.argv) != 3:
         print("Two input arguments are required:")
         print(" 1. A data directory")
         print(" 2. A JSON parameters file")
     else:
-        with open(sys.argv[2], "r",) as f:
+        with open(
+            sys.argv[2],
+            "r",
+        ) as f:
             parameters = json.load(f)
-
         directory = sys.argv[1]
 
         print("Running generate_report.py with parameters:")
@@ -337,5 +343,15 @@ if __name__ == "__main__":
 
         if not os.path.exists(directory):
             raise ValueError(f"Data directory {directory} does not exist.")
+
+        output_content = output_stream.getvalue()
+
+        outfile = os.path.join(directory, "ephys-rig-QC_output.txt")
+
+        with open(outfile, "a") as output_file:
+            output_file.write(
+                datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n"
+            )
+            output_file.write(output_content)
 
         generate_qc_report(directory, **parameters)

--- a/src/aind_ephys_rig_qc/generate_report.py
+++ b/src/aind_ephys_rig_qc/generate_report.py
@@ -11,6 +11,8 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 from open_ephys.analysis import Session
+import shutil
+import os
 
 from aind_ephys_rig_qc import __version__ as package_version
 from aind_ephys_rig_qc.pdf_utils import PdfReport
@@ -321,6 +323,8 @@ def create_qc_plots(
 
 
 if __name__ == "__main__":
+    output_stream = io.StringIO()
+    sys.stdout = output_stream
     if len(sys.argv) != 3:
         print("Two input arguments are required:")
         print(" 1. A data directory")
@@ -328,7 +332,6 @@ if __name__ == "__main__":
     else:
         with open(sys.argv[2], "r",) as f:
             parameters = json.load(f)
-
         directory = sys.argv[1]
 
         print("Running generate_report.py with parameters:")
@@ -338,4 +341,13 @@ if __name__ == "__main__":
         if not os.path.exists(directory):
             raise ValueError(f"Data directory {directory} does not exist.")
 
+        output_content = output_stream.getvalue()
+
+        outfile = os.path.join(directory, "ephys-rig-QC_output.txt")
+
+        with open(outfile, "a") as output_file:
+            output_file.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n")
+            output_file.write(output_content)
+
+        
         generate_qc_report(directory, **parameters)

--- a/src/aind_ephys_rig_qc/qc_figures.py
+++ b/src/aind_ephys_rig_qc/qc_figures.py
@@ -77,7 +77,11 @@ def plot_raw_data(
 
 
 def plot_power_spectrum(
-    data, start_frames, stream_name, sample_rate, chunk_size=10000,
+    data,
+    start_frames,
+    stream_name,
+    sample_rate,
+    chunk_size=10000,
 ):
     """
     Plot the power spectrum of the data
@@ -250,7 +254,9 @@ def plot_drift(directory, stream_name, block_index=0):
     ylim = [np.min(y_locs), np.max(y_locs)]
 
     fig = Figure(figsize=visualization_drift_params["figsize"])
-    axs_drift = fig.subplots(ncols=recording.get_num_segments(),)
+    axs_drift = fig.subplots(
+        ncols=recording.get_num_segments(),
+    )
     # for testing purposes
     if recording.get_total_duration() < 3:
         visualization_drift_params["n_skip"] = 1

--- a/src/aind_ephys_rig_qc/temporal_alignment.py
+++ b/src/aind_ephys_rig_qc/temporal_alignment.py
@@ -214,10 +214,10 @@ def search_harp_line(recording, directory, pdf=None):
     # pick the line with even distribution overtime
     # and has short inter-event interval
     candidate_lines = lines_to_scan[(p_short > 0.5) & (p_value > 0.95)]
-    if len(candidate_lines)>0:
+    if len(candidate_lines) > 0:
         plt.suptitle(f"Harp line(s) {candidate_lines}")
     else:
-        plt.suptitle('Harp line not detected!', color='red')
+        plt.suptitle("Harp line not detected!", color="red")
 
     if pdf is not None:
         pdf.add_page()
@@ -315,10 +315,10 @@ def align_timestamps(  # noqa
             print("Processing stream: ", main_stream_name)
             main_stream_source_node_id = main_stream.metadata["source_node_id"]
             main_stream_sample_rate = main_stream.metadata["sample_rate"]
-            if 'PXIe' in main_stream_name and flip_NIDAQ:
+            if "PXIe" in main_stream_name and flip_NIDAQ:
                 # flip the NIDAQ stream if sync line is inverted between NIDAQ
                 # and main stream
-                print('Flipping NIDAQ stream as main stream...')
+                print("Flipping NIDAQ stream as main stream...")
                 main_stream_events = events[
                     (events.stream_name == main_stream_name)
                     & (events.processor_id == main_stream_source_node_id)
@@ -470,8 +470,8 @@ def align_timestamps(  # noqa
                     print("Processing stream: ", stream_name)
                     source_node_id = stream.metadata["source_node_id"]
                     sample_rate = stream.metadata["sample_rate"]
-                    if 'PXIe' in stream_name and flip_NIDAQ:
-                        print('Flipping NIDAQ stream...')
+                    if "PXIe" in stream_name and flip_NIDAQ:
+                        print("Flipping NIDAQ stream...")
                         # flip the NIDAQ stream if sync line is inverted
                         # between NIDAQ and main stream
                         events_for_stream = events[

--- a/src/aind_ephys_rig_qc/temporal_alignment.py
+++ b/src/aind_ephys_rig_qc/temporal_alignment.py
@@ -214,7 +214,10 @@ def search_harp_line(recording, directory, pdf=None):
     # pick the line with even distribution overtime
     # and has short inter-event interval
     candidate_lines = lines_to_scan[(p_short > 0.5) & (p_value > 0.95)]
-    plt.suptitle(f"Harp line(s) {candidate_lines}")
+    if len(candidate_lines)>0:
+        plt.suptitle(f"Harp line(s) {candidate_lines}")
+    else:
+        plt.suptitle('Harp line not detected!', color='red')
 
     if pdf is not None:
         pdf.add_page()


### PR DESCRIPTION
This PR made two changes: 

1. When there's no harp clock detected, there will be error log in the printed output and also a red title on the harp line plot like this: ![harp_line_search](https://github.com/user-attachments/assets/cfb1f80e-59a7-4689-8cdf-fb6666385e32)
2. Save parameters in output file to enable potential debugging. 
`2024-07-31 11:30:17
Running generate_report.py with parameters:
  report_name: QC.pdf
  timestamp_alignment_method: harp
  original_timestamp_filename: original_timestamps.npy
  plot_drift_map: False
  flip_NIDAQ: False`



